### PR TITLE
Oprava validátoru data narození

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,9 +742,9 @@
                 validatiors: {
                     name: { pattern: /^.{2,}\ .{2,}$/ },
                     bday: function(bday) {
-                        var year = bday.getFullYear();
-                        if (year < 1900 || year > (new Date().getFullYear())-18) return false;
-                        return true;
+                        // rozhodny datum pro 18 let je posledni den voleb, tj. 25.5.2019
+                        // pozor, u konstruktoru Date mesic zacina od 0 (leden), proto 4 = kveten
+                        return bday >= new Date(1900, 0, 1) && bday <= new Date(2001, 4, 25); 
                     },
                     tel: { pattern: /^(\+?[0-9 \-\.]{9,})?$/ },
                     line1: { pattern: /^.{2,} \d{1,}$/ },


### PR DESCRIPTION
Validátor povolil neplatné datum, protože kontroloval pouze rok a ne už den a měsíc.
Rozhodné datum pro dovršení 18 let je poslední den voleb, takže v našem případě 25.5.2019 - 18 let = 25.5.2001